### PR TITLE
feat: Collapse TV show categories by default

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1075,10 +1075,10 @@
             <div class="tv-categories">
                 <div class="tv-category">
                     <div class="collapse-header" data-toggle="collapse" data-target="#ongoing-shows"
-                        aria-expanded="true">
+                        aria-expanded="false">
                         <h4>Currently Watching</h4>
                     </div>
-                    <div id="ongoing-shows" class="collapse show">
+                    <div id="ongoing-shows" class="collapse">
                         {% for show in tv_shows|selectattr('status', 'equalto', 'ongoing')|sort(attribute='title') %}
                         <div class="card my-2 alert-success">
                             <div class="card-header collapse-header" data-toggle="collapse"
@@ -1178,10 +1178,10 @@
 
                 <div class="tv-category">
                     <div class="collapse-header" data-toggle="collapse" data-target="#on-hold-shows"
-                        aria-expanded="true">
+                        aria-expanded="false">
                         <h4>On Hold</h4>
                     </div>
-                    <div id="on-hold-shows" class="collapse show">
+                    <div id="on-hold-shows" class="collapse">
                         {% for show in tv_shows|selectattr('status', 'equalto', 'on_hold')|sort(attribute='title') %}
                         <div class="card my-2 alert-success">
                             <div class="card-header collapse-header" data-toggle="collapse"
@@ -1281,10 +1281,10 @@
 
                 <div class="tv-category">
                     <div class="collapse-header" data-toggle="collapse" data-target="#to-watch-shows"
-                        aria-expanded="true">
+                        aria-expanded="false">
                         <h4>To Watch</h4>
                     </div>
-                    <div id="to-watch-shows" class="collapse show">
+                    <div id="to-watch-shows" class="collapse">
                         {% for show in tv_shows|selectattr('status', 'equalto', 'to_watch')|sort(attribute='title') %}
                         <div class="card my-2 alert-success">
                             <div class="card-header collapse-header" data-toggle="collapse"
@@ -1331,10 +1331,10 @@
 
                 <div class="tv-category">
                     <div class="collapse-header" data-toggle="collapse" data-target="#watched-shows"
-                        aria-expanded="true">
+                        aria-expanded="false">
                         <h4>Completed</h4>
                     </div>
-                    <div id="watched-shows" class="collapse show">
+                    <div id="watched-shows" class="collapse">
                         {% for show in tv_shows|selectattr('status', 'equalto', 'watched')|sort(attribute='title') %}
                         <div class="card my-2 alert-success">
                             <div class="card-header collapse-header" data-toggle="collapse"


### PR DESCRIPTION
The TV show categories ("Currently Watching", "On Hold", "To Watch", "Completed") were expanded by default, making the page difficult to navigate.

This change modifies the `index.html` template to have these categories collapsed by default. This is achieved by setting `aria-expanded="false"` and removing the `show` class from the relevant elements.